### PR TITLE
Qingwei/show tick trade only

### DIFF
--- a/src/_data/LiveData.js
+++ b/src/_data/LiveData.js
@@ -47,9 +47,9 @@ const subscribeToWatchlist = () => {
 };
 
 export const initUnauthorized = () => {
-    api.getActiveSymbolsFull();
     api.getTradingTimes();
     api.getAssetIndex();
+    api.getActiveSymbolsFull();
 
     readNewsFeed().then(articles => api.events.emit('news', articles));
     getVideosFromPlayList().then(videos => api.events.emit('videos', videos));

--- a/src/_reducers/AssetSelectorReducers.js
+++ b/src/_reducers/AssetSelectorReducers.js
@@ -28,9 +28,9 @@ const doFilter = (AssetSelectorList, query, markets, submarket) => {
     ).sort((x1, x2) => x1.get('display_name').localeCompare(x2.get('display_name')));
 };
 
-const hasTick = underlyings => {
-    const withTicks = underlyings.filter(underlying => {
-        return underlying[2].includes('t');
+const hasTick = assets => {
+    const withTicks = assets.filter(asset => {
+        return asset[2].includes('t');
     });
     return withTicks.length > 0;
 };
@@ -38,9 +38,7 @@ const hasTick = underlyings => {
 const tickTradeFilter = assetIndex => {
     const symbolWithTick = assetIndex.filter(asset => {
         return hasTick(asset[2]);
-    }).map(asset => {
-        return asset[0];
-    });
+    }).map(asset => asset[0]);
     return symbolWithTick;
 };
 


### PR DESCRIPTION
This depends on https://github.com/binary-com/binary-next-gen/commit/b358e37d8bf3703e9fdaa533756e4afc17fab212

AssetSelectors and Assets state need to access each other in order to obtain sufficient information to filter out Non-tick trade, result in some useless state and ugly logic used as a workaround.

To solve it elegantly we might need some redesign on redux store shape, now we mainly store whatever we get from api. 
