### PR TITLE
Add unit tests for QuickTradeReducer and ProposalsREducer test

### DIFF
--- a/src/_reducers/__tests__/ProposalsReducer-test.js
+++ b/src/_reducers/__tests__/ProposalsReducer-test.js
@@ -1,0 +1,51 @@
+import expect from 'expect';
+import { fromJS } from 'immutable';
+import proposals from '../ProposalsReducer';
+import { SERVER_DATA_PROPOSAL, UPDATE_PROPOSAL_BY_ID } from '../../_constants/ActionTypes';
+
+describe('ProposalsReducer',()=>{
+    it('should be able to update proposal data with the newly provided server data',()=>{
+        const beforeState = fromJS({});
+        const action = {
+            type: SERVER_DATA_PROPOSAL,
+            serverResponse: {
+                echo_req: {
+                    contract_type: 'Call',
+                    symbol: 'R_100',
+                },
+                proposal: 1,
+            },
+        };
+        const expectedState = fromJS({
+
+            R_100: {
+                Call: 1,
+            },
+        });
+        const actualState = proposals(beforeState,action);
+        expect(actualState).toEqual(expectedState);
+    });
+
+    it('should be able to select proposal by id and update it with new proposal provided',()=>{
+        const beforeState = fromJS({});
+        const action = {
+            type: UPDATE_PROPOSAL_BY_ID,
+            id: 0,
+            proposal: 1,
+        };
+        const expectedState = fromJS({
+            0: 1,
+        });
+        const actualState = proposals(beforeState,action);
+        expect(actualState.toJS()).toEqual(expectedState.toJS());
+    });
+
+    it('should return thesame propsal state when proposal type is not provided',()=>{
+        const beforeState = fromJS({});
+        const action = {
+            proposal: 1,
+        };
+        const actualState = proposals(beforeState,action);
+        expect(actualState).toEqual(beforeState);
+    });
+});

--- a/src/_reducers/__tests__/QuickTradeReducer-test.js
+++ b/src/_reducers/__tests__/QuickTradeReducer-test.js
@@ -1,0 +1,51 @@
+import expect from 'expect';
+import QuickTrade from '../QuickTradeReducer';
+import { UPDATE_QUICK_TRADE_PARAMS, SET_QUICK_TRADE_FIELD } from '../../_constants/ActionTypes';
+import { fromJS } from 'immutable';
+
+describe('QuickTradeReducer',()=>{
+    it('should update quick trade parameters',()=>{
+        const action = {
+            type: UPDATE_QUICK_TRADE_PARAMS,
+            symbol: 'FX',
+            tradeType: 'FOREX',
+            params: {
+                PR: 'value',
+                FT: 3
+            },
+        };
+        const beforeState = fromJS({});
+        const expectedState = fromJS({
+            FX: {
+                FOREX: {
+                    params: {
+                        PR: 'value',
+                        FT: 3,
+                    },
+                },
+            },
+        });
+        const actualState = QuickTrade(beforeState,action);
+        expect(actualState).toEqual(expectedState);
+    });
+
+    it('should be able to set quickTrade field and value',()=>{
+        const action = {
+            type: SET_QUICK_TRADE_FIELD,
+            symbol: 'FX',
+            tradeType: 'FOREX',
+            field: 'amount',
+            value: 0,
+        };
+        const beforeState = fromJS({});
+        const expectedState = fromJS({
+            FX: {
+                FOREX: {
+                    amount: 0
+                }
+            }
+        });
+        const actualState = QuickTrade(beforeState,action);
+        expect(actualState.toJS()).toEqual(expectedState.toJS());
+    })
+})


### PR DESCRIPTION
Hi,

As mentioned in the title above, attached contain the unit test implementation for the two reducers(i.e QuickTradeReducer and ProposalsReducer)

Warm regard;
