### PR TITLE
Use adjust_start_time flag in ticks_history call

### DIFF
--- a/src/_actions/TickActions.js
+++ b/src/_actions/TickActions.js
@@ -22,12 +22,12 @@ export const getTicksBySymbol = symbol =>
         const license = feedLicenses.get(symbol);
         if (!ticks.get(symbol)) {
             if (!license) {
-                LiveData.api.getTickHistory(symbol, { end: 'latest', count: 60 });
+                LiveData.api.getTickHistory(symbol, { end: 'latest', count: 60, adjust_start_time: 1 });
                 LiveData.api.subscribeToTick(symbol);
             }
 
             if (license !== 'chartonly') {
-                LiveData.api.getTickHistory(symbol, { end: 'latest', count: 60 });
+                LiveData.api.getTickHistory(symbol, { end: 'latest', count: 60, adjust_start_time: 1 });
             }
 
             if (license === 'realtime') {

--- a/src/_actions/WorkspaceActions.js
+++ b/src/_actions/WorkspaceActions.js
@@ -25,7 +25,7 @@ export const selectAssetSymbolForTrade = (newSymbol, oldSymbol) =>
     dispatch => {
         dispatch(clearTradeTicks());
         dispatch(changeSelectedAsset(newSymbol));
-        LiveData.api.getTickHistory(newSymbol, { end: 'latest', count: 60 });
+        LiveData.api.getTickHistory(newSymbol, { end: 'latest', count: 60, adjust_start_time: 1 });
         LiveData.api.unsubscribeFromTick(oldSymbol);
         LiveData.api.subscribeToTick(newSymbol);
     };

--- a/src/_data/LiveData.js
+++ b/src/_data/LiveData.js
@@ -46,7 +46,7 @@ const subscribeToSelectedSymbol = store => {
     if (state.workspace && state.workspace.get('selectedAsset')) {
         const symbol = state.workspace.get('selectedAsset');
         store.dispatch(actions.getTradingOptions(symbol, () => {
-            api.getTickHistory(symbol, { end: 'latest', count: 60 });
+            api.getTickHistory(symbol, { end: 'latest', count: 60, adjust_start_time: 1 });
             api.subscribeToTick(symbol);
         }));
     }


### PR DESCRIPTION
This flag will ensure we do receive ticks history

I think it's better to not place this in binary-live-api, ping me if any of you think otherwise
