### PR TITLE
Hide the close icon when there is only one trade

### DIFF
--- a/src/trades/TradeHeader.js
+++ b/src/trades/TradeHeader.js
@@ -5,16 +5,19 @@ export default class TradeHeaders extends Component {
 
     static propTypes = {
         assetName: PropTypes.string.isRequired,
+        closable: PropTypes.bool,
         onClosePanel: PropTypes.func.isRequired,
     };
-
+    static defaultProps = {
+        closable: true,
+    };
     render() {
-        const { assetName, onClosePanel } = this.props;
+        const { assetName, onClosePanel, closable } = this.props;
 
         return (
             <div className="trade-header inverse">
                 <span>{assetName}</span>
-                <CloseButton onClick={onClosePanel} />
+                {closable && <CloseButton onClick={onClosePanel} />}
             </div>
         );
     }

--- a/src/trades/TradesGrid.js
+++ b/src/trades/TradesGrid.js
@@ -21,7 +21,7 @@ export default class TradesGrid extends Component {
 
     render() {
         const { actions, activeTradeIndex, assetsIsOpen, currency, trades, ticksForAllSymbols, contracts } = this.props;
-
+        const closable = trades.length > 1;
         return (
             <div className="trades-grid">
                 {trades.map((trade, index) =>
@@ -32,6 +32,7 @@ export default class TradesGrid extends Component {
                     >
                         <TradeHeader
                             assetName={trade.symbolName}
+                            closable={closable}
                             onClosePanel={ev => {
                                 actions.removeTrade(index);
                                 ev.stopPropagation();

--- a/src/trades/TradesTabs.js
+++ b/src/trades/TradesTabs.js
@@ -28,6 +28,7 @@ export default class TradesTabs extends Component {
     render() {
         const { actions, activeTradeIndex, assetsIsOpen, contracts, trades, ticksForAllSymbols, currency } = this.props;
         const activeTrade = trades[activeTradeIndex];
+        const closable = trades.length > 1;
         return (
             <div className="trades-tabs">
                 <TabList
@@ -38,7 +39,7 @@ export default class TradesTabs extends Component {
                         <Tab
                             key={index}
                             text={trade.symbolName}
-                            closable
+                            closable={closable}
                             onClose={() => {
                                 actions.removeTrade(index);
                             }}


### PR DESCRIPTION
Hi,

Attached contained few changes that should address the card here https://trello.com/c/gKGLvNRi/186-remove-the-close-button-if-there-is-only-one-trade-window for your perusal. 
