### PR TITLE
Befitting layout for mobile trade and margin for mobile pages

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -150,7 +150,21 @@ div[role=tab] .close-btn, .panel-active .close-btn {
     overflow: auto;
     width: 100%;
 }
-
+.mobile-content > .trade-panel > div:last-child {
+    margin: auto;
+    margin-top: 1em;
+    max-width: 100% !important;
+}
+.mobile-content > .news-list-card,
+.mobile-content > .asset-index-card, 
+.mobile-content > .video-list,
+.mobile-content > .trading-times-card
+{
+    margin: 0 .3em 0 .3em;
+}
+.setting-container {
+    margin: 0 .3em 0 .3em;
+}
 [role=tablist] {
     margin-bottom: .5rem;
     flex-shrink: 0;

--- a/src/settings/SettingsChangePassword.js
+++ b/src/settings/SettingsChangePassword.js
@@ -57,7 +57,7 @@ export default class SettingsChangePassword extends React.Component {
     render() {
         const { validatedOnce, passwordNotValid, passwordsDontMatch, successMessage, errorMessage } = this.state;
         return (
-            <div className="startup-content">
+            <div className="startup-content setting-container">
                 <div className="mobile-form" onSubmit={e => e.preventDefault()}>
                     <form className="mobile-form" onSubmit={e => e.preventDefault()}>
                         <InputGroup

--- a/src/settings/SettingsDetails.js
+++ b/src/settings/SettingsDetails.js
@@ -13,7 +13,7 @@ export default class SettingsDetails extends Component {
 		const { settings } = this.props;
 
 		return (
-			<div>
+			<div className="setting-container">
 				<legend>
 					<M m="Details" />
 				</legend>

--- a/src/settings/SettingsGeneral.js
+++ b/src/settings/SettingsGeneral.js
@@ -36,7 +36,7 @@ export default class SettingsGeneral extends Component {
         const topupVirtual = this.props.settings.topup_virtual;
 
 		return (
-			<div>
+			<div className="setting-container">
 				<label htmlFor="language-picker"><M m="Language" /></label>
 				<LanguagePicker id="language-picker" />
 				<label htmlFor="theme-picker"><M m="Color Theme" /></label>

--- a/src/settings/SettingsLimits.js
+++ b/src/settings/SettingsLimits.js
@@ -12,7 +12,7 @@ export default class SettingsLimits extends Component {
 		const { settings } = this.props;
 
 		return (
-			<div>
+			<div className="setting-container">
 				<h2>
 					<M m="Trading Limits" />
 				</h2>

--- a/src/settings/SettingsSecurity.js
+++ b/src/settings/SettingsSecurity.js
@@ -59,7 +59,7 @@ export default class SettingsSecurity extends Component {
 		const { settings } = this.props;
         const { password1, password2 } = this.state;
 		return (
-			<div className="mobile-form">
+			<div className="mobile-form setting-container">
 				<p>
 					<M m="An additional password can be used to restrict access to the cashier." />
 				</p>

--- a/src/settings/SettingsSelfExclusion.js
+++ b/src/settings/SettingsSelfExclusion.js
@@ -53,7 +53,7 @@ export default class SettingsSelfExclusion extends Component {
 	render() {
 		const { settings } = this.props;
 		return (
-			<div className="mobile-form">
+			<div className="mobile-form setting-container">
 				<InputGroup
 					id="MAXCASHBAL"
 					label="Maximum account cash balance"


### PR DESCRIPTION
Hi ,

Attached contained few stylings that should add a befitting margins and layout for our mobile version. Example , below are our existing mobile design.

![image](https://cloud.githubusercontent.com/assets/12234030/15068477/28f0830e-13aa-11e6-81eb-85945f89873f.png)

Daily report 

![image](https://cloud.githubusercontent.com/assets/12234030/15068493/41fd192a-13aa-11e6-9246-7f1d6eb28b36.png)

and binary tv.

![image](https://cloud.githubusercontent.com/assets/12234030/15068502/4fe5f282-13aa-11e6-951f-3b28db4d837c.png)

and mobile trade with this PR.

![image](https://cloud.githubusercontent.com/assets/12234030/15068516/77332206-13aa-11e6-8998-c27c548e7b6c.png)

binary tv with the changes 

![image](https://cloud.githubusercontent.com/assets/12234030/15068527/9220b358-13aa-11e6-9314-94e11a665704.png)

etc.
