### PR TITLE
Fix trading times Real account issue

### DIFF
--- a/src/trading-times/TradingTimesCard.js
+++ b/src/trading-times/TradingTimesCard.js
@@ -18,7 +18,8 @@ export default class TradingTimesCard extends Component {
 	assetMatchFilter(symbolName, filter) {
 		const { assets } = this.props;
 		const assetObj = assets.find(x => x.symbol === symbolName);
-		return assetObj.market === filter || assetObj.submarket === filter;
+		const returnObj = assetObj ? (assetObj.market === filter || assetObj.submarket === filter) : null;
+		return returnObj;
 	}
 
 	render() {


### PR DESCRIPTION
Hi,

Attached contained few changes that should address our issue stated on the card here https://trello.com/c/xjRHpuDz/330-tradingtimes-not-working-in-real-account.  Active_symbols varries with landing company. For VRT accounts, all the symbols are returned instead. 
