### PR TITLE
Fix start later mobile height

### DIFF
--- a/www/scss/_mobile.scss
+++ b/www/scss/_mobile.scss
@@ -23,6 +23,30 @@
   .setting-container > .asset-index-card {
     margin: 0 .25em 0 .25em;
   }
+  .trade-chart-container{
+    min-height: 50%;
+    max-height: 50%;
+  }
+  .trade-params{
+    font-size: .65em;
+
+    > div {
+        input[type="number"],
+        input[type="text"],
+        input[type="date"],
+        input[type="time"],
+        img,
+        svg,
+        select,
+        btn-flat {
+          height: 3em;
+      }
+
+
+
+    }
+
+  }
 
   > {
     .video-list {

--- a/www/scss/_trade_params.scss
+++ b/www/scss/_trade_params.scss
@@ -220,7 +220,6 @@
 }
 .payout-picker button {
   width: 2rem;
-  height: 2rem;
 }
 .forward-starting-picker > * {
   flex: 1;


### PR DESCRIPTION
Hi,

Attached contained few changes that should address the mobile issue mentioned on the ticket here https://trello.com/c/Nk8Qbc6G/469-navigator-is-covered-by-trade-params for your perusal.

before PR

![image](https://cloud.githubusercontent.com/assets/12234030/15959428/5ac78258-2f2d-11e6-9ce3-99903f59b13d.png)

with the PR

![image](https://cloud.githubusercontent.com/assets/12234030/15959367/03ee20cc-2f2d-11e6-8f43-d771af22fb44.png)

Notice the chart navigation disappear in the before. This is because its suppress by the tradeparams.
