### PR TITLE
Set flag to enable sourcemap

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "style-loader": "^0.13.1",
     "stylelint-config-standard": "^9.0.0",
     "stylelint-webpack-plugin": "^0.2.0",
-    "webpack": "^1.13.1",
+    "webpack": "^2.1.0-beta.4",
     "webpack-dev-middleware": "^1.6.1",
     "webpack-hot-middleware": "^2.10.0",
     "webpack-notifier": "^1.3.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,7 +19,9 @@ module.exports = {
             },
         }),
         new webpack.optimize.DedupePlugin(),
-        new webpack.optimize.UglifyJsPlugin()
+        new webpack.optimize.UglifyJsPlugin({
+            sourceMap: true,
+        })
     ] : [
         new styleLintPlugin(),
         new webpack.HotModuleReplacementPlugin(),


### PR DESCRIPTION
Turn out they change the default in webpack 2.0, we just have to enable it
