### PR TITLE
Nuru/fix statusbar

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -13,6 +13,7 @@
     <plugin name="cordova-plugin-splashscreen" version="3.2.2" />
     <plugin name="cordova-plugin-keyboard" version="1.1.4" />
     <plugin name="cordova-plugin-inappbrowser" value="CDVInAppBrowser" />
+    <plugin name="cordova-plugin-statusbar" version="2.1.3" />
     <allow-navigation href="*" />
     <access origin="*" />
     <allow-intent href="http://*/*" />

--- a/www/index.html
+++ b/www/index.html
@@ -62,6 +62,9 @@
             },
             onDeviceReady: function() {
                 document.addEventListener("backbutton", onBackPressed, false);
+                if (cordova.platformId.toLowerCase() === 'ios') {
+                    StatusBar.hide();
+                }
                 codePush.sync();
             },
             // onDeviceResume: function () {


### PR DESCRIPTION
Hi,

Attached contained few changes that should add support for status bar plugin for our device. If you don't want to use plugin, you can add the following line in MainViewController.m . probably inside ios platform folder.

```

//fix not hide status on ios7
- (BOOL)prefersStatusBarHidden
{
    return YES;
}
```

The plugin offer many option though. You can hide, show, change color, modify the statusbar as described here. https://github.com/apache/cordova-plugin-statusbar . If you choose the first solution, you can discard the index.html, config.xml changes . Either of the would work. I tested.
