### PR TITLE
Set default color for root class

### DIFF
--- a/styles/_basic.scss
+++ b/styles/_basic.scss
@@ -15,6 +15,7 @@ body {
     width: 100%;
     height: 100%;
     display: flex;
+    background-color: white;
 }
 
 .disabled {


### PR DESCRIPTION
Hi,

When i fullscreen, firefox tend to change set black as the default color of the body hence the need for setting the default color externally. 
