### PR TITLE
Set watchlist-card height to auto

### DIFF
--- a/styles/_watchlist.scss
+++ b/styles/_watchlist.scss
@@ -8,7 +8,7 @@
 
 .watchlist-card {
     width: 100%;
-    height: 100%;
+    height: auto;
     padding: 0.25rem;
     overflow: auto;
     -webkit-overflow-scrolling: touch;


### PR DESCRIPTION
Hi,

`watchlist-card` css class should not have a % height because it parent container has no fix height. THe parent class has fix width but no fix height. While other browsers work regardless, safari failed .
