### PR TITLE
Fix start later time issue in FF and safari

### DIFF
--- a/src/duration-picker/ForwardStartingOptions.js
+++ b/src/duration-picker/ForwardStartingOptions.js
@@ -1,6 +1,6 @@
 import React, { PureComponent, PropTypes } from 'react';
 import { epochToUTCTimeString, dateToEpoch,
-    timeStringToSeconds, dateToDateString, returnValidaDate, returnValidTime } from 'binary-utils';
+    timeStringToSeconds, dateToDateString, returnValidDate, returnValidTime } from 'binary-utils';
 import { M, Label } from 'binary-components';
 import { createDefaultStartLaterEpoch } from '../trade-params/DefaultTradeParams';
 import { changeStartDate } from '../trade-params/TradeParamsCascadingUpdates';
@@ -33,7 +33,7 @@ export default class ForwardStartingOptions extends PureComponent {
 
     onDayChange = e => {
         const { dateStart } = this.props;
-        const inputValue = returnValidaDate(e.target.value, '-');
+        const inputValue = returnValidDate(e.target.value, '-');
         const newDayEpoch = dateToEpoch(new Date(inputValue));
         const secondsPerDay = 60 * 60 * 24;
         const intraDayEpoch = dateStart % secondsPerDay;

--- a/src/duration-picker/ForwardStartingOptions.js
+++ b/src/duration-picker/ForwardStartingOptions.js
@@ -1,6 +1,6 @@
 import React, { PureComponent, PropTypes } from 'react';
 import { epochToUTCTimeString, dateToEpoch,
-    timeStringToSeconds, dateToDateString } from 'binary-utils';
+    timeStringToSeconds, dateToDateString, returnValidaDate, returnValidTime } from 'binary-utils';
 import { M, Label } from 'binary-components';
 import { createDefaultStartLaterEpoch } from '../trade-params/DefaultTradeParams';
 import { changeStartDate } from '../trade-params/TradeParamsCascadingUpdates';
@@ -33,7 +33,7 @@ export default class ForwardStartingOptions extends PureComponent {
 
     onDayChange = e => {
         const { dateStart } = this.props;
-        const inputValue = e.target.value;
+        const inputValue = returnValidaDate(e.target.value, '-');
         const newDayEpoch = dateToEpoch(new Date(inputValue));
         const secondsPerDay = 60 * 60 * 24;
         const intraDayEpoch = dateStart % secondsPerDay;
@@ -42,9 +42,7 @@ export default class ForwardStartingOptions extends PureComponent {
 
     onTimeChange = e => {
         const { dateStart } = this.props;
-        const inputValue = e.target.value.split(':')
-                         .map((obj) => obj.length < 2 ? '0' + obj : obj)
-                         .join(':');
+        const inputValue = returnValidTime(e.target.value, ':');
         const secondsPerDay = 60 * 60 * 24;
         const intraDayEpoch = dateStart % secondsPerDay;
         const dayEpoch = dateStart - intraDayEpoch;

--- a/src/duration-picker/ForwardStartingOptions.js
+++ b/src/duration-picker/ForwardStartingOptions.js
@@ -42,7 +42,9 @@ export default class ForwardStartingOptions extends PureComponent {
 
     onTimeChange = e => {
         const { dateStart } = this.props;
-        const inputValue = e.target.value;
+        const inputValue = e.target.value.split(':')
+                         .map((obj) => obj.length < 2 ? '0' + obj : obj)
+                         .join(':');
         const secondsPerDay = 60 * 60 * 24;
         const intraDayEpoch = dateStart % secondsPerDay;
         const dayEpoch = dateStart - intraDayEpoch;


### PR DESCRIPTION
Hi, 

Attached contain little changes that should address the card here for your perusal. 
https://trello.com/c/jLKYQwhV/765-firefox-and-safari-parameters-of-the-trading-will-be-reset-if-user-modify-the-start-time
