### PR TITLE
OSx scroll

### DIFF
--- a/styles/_app.scss
+++ b/styles/_app.scss
@@ -12,4 +12,13 @@
         -ms-user-select: none;
         user-select: none;
     }
+    ::-webkit-scrollbar {
+        -webkit-appearance: none;
+        width: .5em;
+    }
+    ::-webkit-scrollbar-thumb {
+        border-radius: .3em;
+        background-color: rgba(0,0,0,.5);
+        box-shadow: 0 0 1px rgba(255,255,255,.5);
+    }
 }


### PR DESCRIPTION
Hi,

Osx systems does not seems to show scroll unless user attempt to scroll . This looks confusing for users who do not know or were not expecting the scroll. The third bug from the list https://trello.com/c/gilbvwEc/9-safari-bugs

With PR 

![image](https://cloud.githubusercontent.com/assets/12234030/17289253/741b945e-580b-11e6-9994-244fa28f7183.png)

without PR 

![image](https://cloud.githubusercontent.com/assets/12234030/17289544/bd5dce24-580c-11e6-908b-84a0b172ccd9.png)
