### PR TITLE
Last layout fix for FF'

### DIFF
--- a/styles/_trade-params.scss
+++ b/styles/_trade-params.scss
@@ -37,6 +37,8 @@
     .trade-panel {
         flex-direction: row-reverse;
         align-items: stretch;
+        min-width: 0;
+        min-height: 0;
     }
 
     .contract-detail {
@@ -63,6 +65,8 @@
 .horizontal {
     .trade-panel {
         flex-direction: column;
+        min-width: 0;
+        min-height: 0;
     }
 
     .errorfield {
@@ -189,6 +193,7 @@
     flex-direction: column;
     flex: 1;
     min-width: 0;
+    min-height: 0;
     .binary-chart-zoom-controls {
         visibility: hidden;
         opacity: 0;


### PR DESCRIPTION
Last tweak up my sleeve with regard to FF issue. Firefox has some little issue with flex as noted here http://stackoverflow.com/questions/34982834/rendering-problems-using-flexbox-in-firefox-and-chrome-48 and http://stackoverflow.com/questions/26895349/how-can-i-get-ff-33-x-flexbox-behavior-in-ff-34-x . You may come across similar issue that can be resolved by simply setting the default or initial width an height. 😉  
