### PR TITLE
bug fix: hidden timeout validation error message.

### DIFF
--- a/src/settings/SettingsSelfExclusion.js
+++ b/src/settings/SettingsSelfExclusion.js
@@ -150,6 +150,7 @@ export default class SettingsSelfExclusion extends PureComponent {
       max_30day_turnover, max_30day_losses, max_open_bets, session_duration_limit,
       exclude_until, timeout_until_date, timeout_until_time, success, serverError, touched, errors } = this.state;
     // const wrongExcludeUntillTime = isValidTime(timeout_until_time);
+    const timeout_until = touched.timeout_until_date || touched.timeout_until_time;
     return (
       <div className="settings-self-exclusion">
         <form onSubmit={this.onFormSubmit}>
@@ -253,7 +254,7 @@ export default class SettingsSelfExclusion extends PureComponent {
             defaultValue={timeout_until_date || 'yyyy-mm-dd'}
             onChange={this.onEntryChange}
           />
-          {touched.timeout_until_date && <ErrorMsg text={head((errors || {}).timeout_until_date)} />}
+          {timeout_until && <ErrorMsg text={head((errors || {}).timeout_until_date)} />}
           <InputGroup
             id="timeout_until_time"
             label="Time out until time"
@@ -262,7 +263,7 @@ export default class SettingsSelfExclusion extends PureComponent {
             defaultValue={timeout_until_time || '--:--:--'}
             onChange={this.onEntryChange}
           />
-          {touched.timeout_until_time && <ErrorMsg text={head((errors || {}).timeout_until_time)} />}
+          {timeout_until && <ErrorMsg text={head((errors || {}).timeout_until_time)} />}
           <InputGroup
             id="exclude_until"
             label="Exclude me from the website until"

--- a/src/settings/SettingsSelfExclusion.validation.config.js
+++ b/src/settings/SettingsSelfExclusion.validation.config.js
@@ -18,6 +18,11 @@ validate.validators.timeoutUntilTimeRequired = (value, options) => {
     return 'This field is required.';
   }
 };
+validate.validators.timeoutUntilDateRequired = (value, options) => {
+  if (options.timeout_until_time && !value) {
+    return 'This field is required.';
+  }
+};
 validate.validators.excludeUntilValidation = (value) => {
   if (!!value && moment(value).isBefore(moment())) {
     return 'Exclude time cannot be in the past.';
@@ -229,6 +234,9 @@ export const getConstraints = (props, state) => {
     },
     timeout_until_date: {
       timeoutUntilDateValidation: true,
+      timeoutUntilDateRequired: {
+        timeout_until_time: state.timeout_until_time,
+      },
     },
     timeout_until_time: {
       timeoutUntilTimeRequired: {


### PR DESCRIPTION
Steps to reproduce:
1. Go to Settings > Self Exclusion, and set "Time out until date"
2. Press "Update" and nothing happens.

The QA who initially reported this thought it was successfully updated but did not show up in the app, but in actuality nothing actually did get sent to the Binary web service. There was a validation error, but it was hidden. However, we can show this field by entering values into "Time out until time" field.

This strange behavior happens because the validation error message for a particular field only gets shown after the user enters something (in codebase it is referred as "touched") to that field.

This fix works by showing the error message when either touched.timeout_until_date or touched.timeout_until_time is being "touched". In addition, another validation is added to ensure that if user enters into "Time out until time" he is required to fill "Time out until date". Without this addition, filling out just "Time out until time" doesn't do anything but displays "Settings Updated".