### PR TITLE
fix: [Cordova Android] fields resize when keyboard appears.

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,8 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-versionCode="200000" id="app.binary.com" version="2.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-versionCode="200000" id="app.binary.com" version="2.0.1" 
+    xmlns="http://www.w3.org/ns/widgets" 
+    xmlns:cdv="http://cordova.apache.org/ns/1.0"
+    xmlns:android="http://schemas.android.com/apk/res/android">
     <name>Binary.com</name>
     <description>
         Trade Binary Options with Binary.com
@@ -29,6 +32,10 @@
     <preference name="FadeSplashScreenDuration" value="250" />
     <preference name="StatusBarOverlaysWebView" value="false" />
     <preference name="StatusBarBackgroundColor" value="#2A3052" />
+    <!-- Modify android manifest to prevent keyboard from resizing the view. See: https://stackoverflow.com/q/10076148/1471258 -->
+    <edit-config file="AndroidManifest.xml" mode="merge" target="/manifest/application/activity">
+        <activity android:configChanges="orientation|keyboardHidden" android:windowSoftInputMode="adjustPan" />
+    </edit-config>
     <feature name="SplashScreen">
         <param name="ios-package" value="CDVSplashScreen" />
         <param name="android-package" value="org.apache.cordova.splashscreen.SplashScreen" />


### PR DESCRIPTION
Steps to reproduce:

 * In Binary.com android app, go to settings > self-exclusion
 * tap on any field
 * When the ASUS smartphone, keyboard appears, fields and text resizes. In Samsung tablet, keyboard appears, the input fields shrinks horizontally a few pixels.

See: https://stackoverflow.com/q/10076148/1471258

I also posted my answer there.