### PR TITLE
Trade on closed markets fix

### DIFF
--- a/src/_trade/saga/LifeCycleSaga.js
+++ b/src/_trade/saga/LifeCycleSaga.js
@@ -6,8 +6,6 @@ import { api as CoreApi } from '../../_data/LiveData';
 import changeSymbol from '../updates/changeSymbol';
 import { getForceRenderCount, contractOfSymbol, isSymbolOpen, getParams } from './SagaSelectors';
 import { subscribeProposal, unsubscribeProposal } from './ProposalSubscriptionSaga';
-import { updateTradeError } from '../../_actions/TradeActions';
-
 
 const CREATE_TRADE = 'CREATE_TRADE';
 export const createTrade = (index, symbol) => ({
@@ -33,9 +31,6 @@ export function* tradeCreation(action) {
             put(updateTradeUIState(index, 'forceRenderCount', renderCount + 1)),
             put(subscribeProposal(index, updatedParams)),
         ];
-        if (!isOpen) {
-           yield put(updateTradeError(index, 'serverError', 'The market must be open at the start time.'));
-        }
     } else {
         try {
             const { contracts_for } = yield CoreApi.getContractsForSymbol(symbol);

--- a/src/asset-picker/AssetPickerItem.js
+++ b/src/asset-picker/AssetPickerItem.js
@@ -19,14 +19,12 @@ export default class AssetPickerItem extends PureComponent {
 		selected: false,
 	};
 
-    onRowClicked = (e: SyntheticEvent) => {
-        const { asset, onClose, onSelect } = this.props;
-        if (asset.isOpen) {
-            onSelect(asset.symbol);
-            onClose();
-        }
-        e.stopPropagation();
-    };
+	onRowClicked = (e: SyntheticEvent) => {
+		const { asset, onClose, onSelect } = this.props;
+		onSelect(asset.symbol);
+		onClose();
+		e.stopPropagation();
+	};
 
 	onStarClicked = (e: SyntheticEvent) => {
 		const { asset, onToggleWatchlistItem } = this.props;

--- a/styles/_asset-picker.scss
+++ b/styles/_asset-picker.scss
@@ -54,11 +54,6 @@
 }
 
 .asset-picker-item {
-    &.closed {
-      cursor: default;
-      color: $COLOR_INVERSE_TEXT;
-      td:first-child { cursor: pointer; }
-    }
     td {
         text-align: left;
         padding: 0.25em;


### PR DESCRIPTION
bug fix: unable to trade in the future in currently closed markets.

This fix enables markets that are closed, but only allow users to trade in the future. The removed code on `LifeCycleSaga.js` throws an error when the market is currently closed. This is not necessary since we can delegate the error handling to the server, and receive error messages same of that of binary static + translation to other languages.