### PR TITLE
Odd autocomplete implementation with NumericInput

### DIFF
--- a/src/payout-picker/StakeCard.js
+++ b/src/payout-picker/StakeCard.js
@@ -3,7 +3,6 @@ import debounce from 'lodash.debounce';
 import { NumericInput, Label } from 'binary-components';
 import { actions } from '../_store';
 
-const payouts = [1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000];
 const debounceStakeChange = debounce(actions.reqStakeChange, 400);
 
 export default class StakeCard extends PureComponent {
@@ -36,7 +35,6 @@ export default class StakeCard extends PureComponent {
                     min={0}
                     step={step}
                     decimals={decimals}
-                    valueList={payouts}
                     onChange={this.onAmountChange}
                 />
             </div>


### PR DESCRIPTION
So a QA reported this funny autocomplete going completely out of position:

![](https://trello-attachments.s3.amazonaws.com/58ec494d9b6ac14098cc9ef4/59b63035a2257cce286fb8ed/8b1927f9b6a9b75113f90e5b05715ee6/input_selection_go_off.png)

A curious thing is that it only affects android devices. In desktop and in iOS devices this autocomplete doesn't appear. What is this autocomplete doing in the first place?

Turns out it's actually from a `<datalist>` from the stake input. Unfortunately the list attribute in `NumericInput` is hardcoded to be "values" in binary-components, so if we have multiple value lists there's going to be ambiguity; ideally we want the id for each datalist to be unique. So passing a `valueList` prop to `NumericInput` is a bug waiting to happen.

But I have a simpler solution. Why do we need hardcoded payout values in the first place? Binary-static doesn't use it.