### PR TITLE
Bug fix: In android devices (app + browser), keyboard obstructs input fields

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -100,4 +100,5 @@
     <plugin name="cordova-plugin-splashscreen" spec="^3.2.2" />
     <plugin name="cordova-plugin-statusbar" spec="^2.1.3" />
     <plugin name="cordova-plugin-whitelist" spec="^1.3.2" />
+    <plugin name="ionic-plugin-keyboard" spec="^2.2.1" />
 </widget>

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
         "highstock-release": "5.0.10",
         "history": "~4.4.0",
         "immutable": "^3.8.1",
+        "ionic-plugin-keyboard": "^2.2.1",
         "jquery": "^3.2.1",
         "lodash.debounce": "^4.0.8",
         "lodash.throttle": "^4.1.1",
@@ -207,7 +208,8 @@
             "cordova-plugin-inappbrowser": {},
             "cordova-plugin-splashscreen": {},
             "cordova-plugin-statusbar": {},
-            "cordova-plugin-whitelist": {}
+            "cordova-plugin-whitelist": {},
+            "ionic-plugin-keyboard": {}
         }
     }
 }

--- a/src/_data/Auth.js
+++ b/src/_data/Auth.js
@@ -87,7 +87,7 @@ export const requireAuthOnEnter = (nextState, replace, callback) => {
     const { location } = nextState;
     if (!authorized && (rootPaths.indexOf(location.pathname) === -1)) {
         replace({
-            pathname: window.BinaryBoot.redirectUrl,
+            pathname: window.BinaryBoot.baseUrl,
             state: nextState,
         });
     }

--- a/src/containers/MobilePage.js
+++ b/src/containers/MobilePage.js
@@ -20,6 +20,46 @@ export default class MobilePage extends PureComponent {
 	render() {
 		const { backBtnBarTitle, children, toolbarShown, inverse, backTo } = this.props;
 
+		const isAndroidBrowser = /(android)/i.test(navigator.userAgent);
+		// NOTE: A cordova app is also an android browser
+		const isAndroidApp = window.cordova && device.platform === 'Android';
+		const isAndroid = isAndroidApp || isAndroidBrowser;
+
+		if (isAndroid) {
+			// In android devices, there is a strange issue where the keyboard obstructs the input
+			// fields. This hack places a blank space for the keyboard to occupy when it shows up.
+			const inputsBlockedByKeyboard = ['tel', 'password', 'text', 'number', 'textarea'];
+			const getAndroidKeyboardSpace = () => document.getElementById('android-keyboard-space');
+			if (isAndroidApp) {
+				window.addEventListener('native.keyboardshow', (e) => {
+					getAndroidKeyboardSpace().style = 'height: ' + e.keyboardHeight + 'px;';
+					document.activeElement.scrollIntoView();
+				});
+
+				window.addEventListener('native.keyboardhide', () => {
+					getAndroidKeyboardSpace().removeAttribute('style');
+				});
+			} else if (isAndroidBrowser) {
+				// In browser there is no API to know whether keyboard exists or get the keyboard height.
+				// We have to figure it out from the screen and viewport height.
+				const heightOffset = window.screen.height - window.outerHeight;
+				const defaultWindowHeight = window.outerHeight;
+				window.addEventListener('resize', () => {
+					const isKeyboardExist =
+						window.outerHeight < defaultWindowHeight // keyboard shrinks outerHeight when visible
+						&& inputsBlockedByKeyboard.includes(document.activeElement.type);
+					const androidKeyboardSpace = getAndroidKeyboardSpace();
+					if (isKeyboardExist) {
+						const keyboardHeight = window.screen.height - window.outerHeight - heightOffset;
+						androidKeyboardSpace.style = 'height: ' + keyboardHeight + 'px;';
+						document.activeElement.scrollIntoView();
+					} else {
+						androidKeyboardSpace.removeAttribute('style');
+					}
+				});
+			} 
+		}
+
 		return (
 			<div className={inverse ? 'mobile-page inverse' : 'mobile-page'}>
 				{toolbarShown ? <MobileToolbarFull /> : null}
@@ -27,6 +67,7 @@ export default class MobilePage extends PureComponent {
 				<div className="mobile-content">
 					{children}
 				</div>
+				{isAndroid && <div id="android-keyboard-space" />}
 				<IosPadder />
 			</div>
 		);

--- a/src/containers/MobilePage.js
+++ b/src/containers/MobilePage.js
@@ -32,7 +32,7 @@ export default class MobilePage extends PureComponent {
 			const getAndroidKeyboardSpace = () => document.getElementById('android-keyboard-space');
 			if (isAndroidApp) {
 				window.addEventListener('native.keyboardshow', (e) => {
-					getAndroidKeyboardSpace().style = 'height: ' + e.keyboardHeight + 'px;';
+					getAndroidKeyboardSpace().style.height = e.keyboardHeight + 'px';
 					document.activeElement.scrollIntoView();
 				});
 
@@ -51,13 +51,13 @@ export default class MobilePage extends PureComponent {
 					const androidKeyboardSpace = getAndroidKeyboardSpace();
 					if (isKeyboardExist) {
 						const keyboardHeight = window.screen.height - window.outerHeight - heightOffset;
-						androidKeyboardSpace.style = 'height: ' + keyboardHeight + 'px;';
+						androidKeyboardSpace.style.height = keyboardHeight + 'px';
 						document.activeElement.scrollIntoView();
 					} else {
 						androidKeyboardSpace.removeAttribute('style');
 					}
 				});
-			} 
+			}
 		}
 
 		return (

--- a/src/sidebar/AccountMenuItem.js
+++ b/src/sidebar/AccountMenuItem.js
@@ -15,7 +15,7 @@ export default class AccountMenuItem extends PureComponent {
 		if (window.cordova) {
 			window.location.reload(true);
 		} else {
-			window.location.href = window.BinaryBoot.redirectUrl;
+			window.location.href = window.BinaryBoot.baseUrl;
 		}
 	};
 

--- a/src/upgrade/UpgradeToMaltainvestCard.js
+++ b/src/upgrade/UpgradeToMaltainvestCard.js
@@ -130,7 +130,7 @@ export default class UpgradeToMaltainvestCard extends PureComponent {
       });
       const response = await api.createRealAccountMaltaInvest(createAccountParams);
       storage.setItem('account', JSON.stringify({ token: response.new_account_maltainvest.oauth_token }));
-      window.location = window.BinaryBoot.redirectUrl;
+      window.location = window.BinaryBoot.baseUrl;
     } catch (e) {
       this.setState({ serverError: e.error.error.message });
     } finally {

--- a/src/upgrade/UpgradeToRealCard.js
+++ b/src/upgrade/UpgradeToRealCard.js
@@ -72,7 +72,7 @@ export default class UpgradeToRealCard extends PureComponent {
 			});
 			const response = await api.createRealAccount(formData);
 			storage.setItem('account', JSON.stringify({ token: response.new_account_real.oauth_token }));
-			window.location = window.BinaryBoot.redirectUrl;
+			window.location = window.BinaryBoot.baseUrl;
 		} catch (e) {
 			this.setState({ serverError: e.error.error.message });
 		} finally {

--- a/styles/_mobile.scss
+++ b/styles/_mobile.scss
@@ -30,6 +30,10 @@
     flex-direction: column;
     width: 100%;
 
+    .trade-panel .chart-dialog {
+        min-height: 23em;
+    }
+
     .asset-picker-filter .tooltip {
         position: relative;
     }
@@ -92,9 +96,10 @@
     .trade-params {
         display: flex;
         margin-top: 0.5em;
+        margin-bottom: 0.5em;
         flex-direction: column;
         flex-wrap: nowrap;
-        min-height: 16em;
+        min-height: 25em;
 
         .duration-input {
             .numeric-input {
@@ -189,6 +194,7 @@
     height: 3.5em;
     display: flex;
     width: 100%;
+    z-index: 1000;
 }
 
 .mobile-back-btn {

--- a/styles/_mobile.scss
+++ b/styles/_mobile.scss
@@ -99,7 +99,7 @@
         margin-bottom: 0.5em;
         flex-direction: column;
         flex-wrap: nowrap;
-        min-height: 25em;
+        min-height: 21em;
 
         .duration-input {
             .numeric-input {

--- a/www/boot.js
+++ b/www/boot.js
@@ -66,7 +66,7 @@
     parseUrlAndStoreAccountInfo(window.location.href);
     window.BinaryBoot.parseUrl = parseOAuthResponse;
     window.BinaryBoot.isBeta = /beta/g.test(window.location.href);
-    window.BinaryBoot.redirectUrl = window.BinaryBoot.isBeta ? '/beta' : '/';
+    window.BinaryBoot.baseUrl = window.BinaryBoot.isBeta ? '/beta' : '/';
     if(window.cordova) {
         window.BinaryBoot.appId = 1006;
     } else if(window.electron) {
@@ -84,7 +84,7 @@
 
     var redirectIndex = window.location.href.indexOf('?');
     if (~redirectIndex) {
-        window.location.href = window.BinaryBoot.redirectUrl;
+        window.location.href = window.BinaryBoot.baseUrl;
     }
 
     window.BinaryBoot.oAuthUrl = window.BinaryBoot.oAuthUrl || defaultConfig.oAuthUrl;

--- a/www/index.html
+++ b/www/index.html
@@ -20,7 +20,7 @@
         // pops up. Only affects android browsers.
         if (/(android)/i.test(navigator.userAgent)) {
             var viewport = document.querySelector("meta[name=viewport]");
-            viewport.setAttribute("content", "height=" + window.outerHeight + ", width=" + window.outerWidth + ", initial-scale=1.0");
+            viewport.setAttribute("content", "height=" + window.outerHeight + ", width=" + window.outerWidth + ", initial-scale=1.0, minimum-scale=1, maximum-scale=1, user-scalable=no");
         }
 
         if (self === top) {


### PR DESCRIPTION
If there is no space below the input field (i.e. footer), the keyboard will obstruct your view and you can't see what you are typing. The solution took awhile to surface since there isn't much help in google land.

This solution is a hack: a blank space is placed at the bottom of the content for the keyboard to occupy. This blank space must be the height of the keyboard. In cordova a plugin can figure out the height, but in android browsers it is more tricky: the height is inferred based on the device screen height and the window height, since the appearance of the keyboard changes the window height (unique only to android).

Special shoutout to @aminroosta for helping me out in this.