### PR TITLE
Bug fix: accounts list is not working properly.

### DIFF
--- a/src/_utils/AccountHelpers.js
+++ b/src/_utils/AccountHelpers.js
@@ -1,0 +1,15 @@
+import storage from '../_store/storage';
+
+export function addNewAccount(newAccountResponse) {
+    // Set current account:
+    storage.setItem('account', JSON.stringify({ token: newAccountResponse.oauth_token }));
+
+    // Update accounts list:
+    const boot = JSON.parse(storage.getItem('boot'));
+    boot.accounts.push({
+        account: newAccountResponse.client_id,
+        token: newAccountResponse.oauth_token,
+        currency: newAccountResponse.currency || ''
+    });
+    storage.setItem('boot', JSON.stringify(boot));
+}

--- a/src/create-account/CreateAccountCard.js
+++ b/src/create-account/CreateAccountCard.js
@@ -2,8 +2,8 @@ import React, { PureComponent } from 'react';
 import { Notice, Button, Countries, ErrorMsg, ServerErrorMsg, InputGroup, LogoSpinner } from 'binary-components';
 import { isValidPassword } from 'binary-utils';
 import { api } from '../_data/LiveData';
-import storage from '../_store/storage';
 import { actions } from '../_store';
+import { addNewAccount } from '../_utils/AccountHelpers';
 import config from '../config';
 
 type Props = {
@@ -69,7 +69,7 @@ export default class CrateAccountCard extends PureComponent {
                 // utm_medium,
                 // utm_campaign,
             });
-            storage.setItem('account', JSON.stringify({ token: response.new_account_virtual.oauth_token }));
+            addNewAccount(response.new_account_virtual);
             // use react router because we want hash history in mobile
             this.context.router.push('/');
             window.location.reload();

--- a/src/upgrade/UpgradeToMaltainvestCard.js
+++ b/src/upgrade/UpgradeToMaltainvestCard.js
@@ -5,10 +5,10 @@ import {
   ErrorMsg, ServerErrorMsg, Countries, MultiSelectGroup
 } from 'binary-components';
 import { api } from '../_data/LiveData';
-import storage from '../_store/storage';
 import options from './UpgradeCard.options';
 import { getConstraints } from './UpgradeToMaltainvestCard.validation.config';
 import ValidationManager from '../_utils/ValidationManager';
+import { addNewAccount } from '../_utils/AccountHelpers';
 
 export default class UpgradeToMaltainvestCard extends PureComponent {
 
@@ -132,7 +132,7 @@ export default class UpgradeToMaltainvestCard extends PureComponent {
         serverError: false,
       });
       const response = await api.createRealAccountMaltaInvest(createAccountParams);
-      storage.setItem('account', JSON.stringify({ token: response.new_account_maltainvest.oauth_token }));
+      addNewAccount(response.new_account_maltainvest);
       window.location = window.BinaryBoot.baseUrl;
     } catch (e) {
       this.setState({ serverError: e.error.error.message });

--- a/src/upgrade/UpgradeToRealCard.js
+++ b/src/upgrade/UpgradeToRealCard.js
@@ -4,10 +4,10 @@ import {
 	ErrorMsg, ServerErrorMsg, Countries
 } from 'binary-components';
 import { api } from '../_data/LiveData';
-import storage from '../_store/storage';
 import { getConstraints } from './UpgradeToRealCard.validation.config';
 import options from './UpgradeCard.options';
 import ValidationManager from '../_utils/ValidationManager';
+import { addNewAccount } from '../_utils/AccountHelpers';
 
 export default class UpgradeToRealCard extends PureComponent {
 
@@ -70,7 +70,7 @@ export default class UpgradeToRealCard extends PureComponent {
 				serverError: false,
 			});
 			const response = await api.createRealAccount(formData);
-			storage.setItem('account', JSON.stringify({ token: response.new_account_real.oauth_token }));
+			addNewAccount(response.new_account_real);
 			window.location = window.BinaryBoot.baseUrl;
 		} catch (e) {
 			this.setState({ serverError: e.error.error.message });


### PR DESCRIPTION
The accounts list is read from local storage `boot.accounts` array. Prior to this commit this array is only filled during authorisation (login), where next-gen infers the list of accounts from the response url. This array needs to be also updated when accounts are created (virtual, real, malta); ergo the intro of this `addNewAccount` method.

Updating the local storage directly instead of a method that updates both the state and the local storage is harmless in this context, since upon adding a new account the page is always refreshed, thereby copying the values in the local storage to the state.