### PR TITLE
bug fix: unable to sell at market after refresh + portfolio does not …

### DIFF
--- a/src/_actions/PortfolioActions.js
+++ b/src/_actions/PortfolioActions.js
@@ -14,8 +14,10 @@ export const subscribeToOpenContract = contractId =>
         if (!boughtContracts.get(contractId)) {
             return api.subscribeToOpenContract(contractId)
                 .then(response => {
-                    if (Object.keys(response.proposal_open_contract).length > 0) {
-                        return response.proposal_open_contract;
+                    const c = response.proposal_open_contract;
+                    if (Object.keys(c).length > 0) {
+                        c.contract_id = String(c.contract_id);
+                        return c;
                     }
                     return Promise.reject('Contract does not exist');
                 });
@@ -28,7 +30,11 @@ export const getOpenContract = contractId =>
         const boughtContracts = getState().boughtContracts;
         if (!boughtContracts.get(contractId)) {
             return api.getContractInfo(contractId)
-                .then(response => response.proposal_open_contract);
+                .then(response => {
+                    const c = response.proposal_open_contract;
+                    c.contract_id = String(c.contract_id);
+                    return c;
+                });
         }
         return Promise.resolve(boughtContracts.get(contractId).toJS());
     };

--- a/src/_reducers/BoughtContractsReducer.js
+++ b/src/_reducers/BoughtContractsReducer.js
@@ -40,13 +40,14 @@ export default (state = initialState, action) => {
             }
 
             const openContract = convertOpenContract(contract);
+            openContract.contract_id = String(openContract.contract_id);
 
             return state.set(openContract.contract_id, fromJS(openContract));
         }
         case SERVER_DATA_PORTFOLIO: {
             const contracts = action.serverResponse.portfolio.contracts;
             return contracts
-                .reduce((prev, curr) => prev.mergeIn([curr.contract_id], curr), state);
+                .reduce((prev, curr) => prev.mergeIn([String(curr.contract_id)], curr), state);
         }
         case SERVER_DATA_TRANSACTION: {
             const tx = action.serverResponse.transaction;


### PR DESCRIPTION
…remove expired contracts

contract_id is expected to be a string, but number is returned. Alternately you could convert to number (the API is supposedly returning Number, but perl somehow converts it to string), but changing to string requires less modifications.