### PR TITLE
fixed issue of scrolling in firefox

### DIFF
--- a/styles/_mobile.scss
+++ b/styles/_mobile.scss
@@ -28,6 +28,7 @@
     align-content: stretch;
     flex-direction: column;
     width: 100%;
+    min-height: 0;
 
     .trade-panel .chart-dialog {
         min-height: 23em;


### PR DESCRIPTION
turns out that min-sizing behavior in flex items (in firefox) breaks scroll in it's child. so setting the min-height equal to 0 will fix this issue.