### PR TITLE
Bug fix: travis script deploys beta to production.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
   - cd ..
 script:
   - cd build
-  - sudo yarn build
+  - yarn build
   - cd ..
 after_success:
   - if [ "$TRAVIS_BRANCH" = "dev" ] ; then rm -fR beta && mkdir beta && mv dist/* beta/ && mv beta dist/; fi
@@ -53,10 +53,10 @@ after_success:
   - rm -fR gh-pages
 before_deploy:
   - git tag "$(date +'%Y-%m-%dT%H%M')-$(git log --format=%h -1)"
-  - sudo cp -R ./dist/* ./www/
-  - sudo cordova platform add android
-  - sudo yarn build:android
-  - sudo mv ./platforms/android/build/outputs/apk/debug/android-debug.apk ./platforms/android/build/outputs/apk/debug/next-gen-beta.apk 
+  - cp -R ./dist/* ./www/
+  - cordova platform add android
+  - yarn build:android
+  - mv ./platforms/android/build/outputs/apk/debug/android-debug.apk ./platforms/android/build/outputs/apk/debug/next-gen-beta.apk 
 deploy:
   provider: releases
   prerelease: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ after_success:
   - rm -fR gh-pages
 before_deploy:
   - git tag "$(date +'%Y-%m-%dT%H%M')-$(git log --format=%h -1)"
-  - cp -R ./dist/* ./www/
+  - if [ "$TRAVIS_BRANCH" = "dev" ] ; then cp -R ./dist/beta/* ./www/; else cp -R ./dist/* ./www/; fi
   - cordova platform add android
   - yarn build:android
   - mv ./platforms/android/build/outputs/apk/debug/android-debug.apk ./platforms/android/build/outputs/apk/debug/next-gen-beta.apk 


### PR DESCRIPTION
So... big mistake on my part. Reason why I didn't notice was because the error messages does not caused the build to throw an error, and travis folds the output of the command.

The `sudo` command caused files and folders to be created with elevated privileges; commands without `sudo` cannot access them. This is why the `mv` command failed to move the compiled site to the `beta` folder in `dev` branch. 