### PR TITLE
bug fix: when user hit `Unknown Contract Proposal` error the `Purchas…

### DIFF
--- a/src/trade-params/TradeParams.js
+++ b/src/trade-params/TradeParams.js
@@ -192,7 +192,7 @@ export default class TradeParams extends PureComponent {
                 <BuyButton
                     askPrice={askPrice}
                     currency={currency}
-                    disabled={disabled}
+                    disabled={purchasing || disabled}
                     longcode={longcode}
                     onClick={this.onPurchase}
                 />


### PR DESCRIPTION
…e` button will be kept disabled.

You can reproduce this by spamming the Purchase button.

There's usually a slight delay while next-gen purchases the contract; during this period the Purchase button should also be disabled.