### PR TITLE
fix error of default currency (happens only in slower connections, it…

### DIFF
--- a/src/_reducers/AccountReducer.js
+++ b/src/_reducers/AccountReducer.js
@@ -22,7 +22,7 @@ const initialState = fromJS({
     currencies_config: { }, // "USD": { "fractional_digits": 2, "stake_default": 0.35, "type": "fiat" }
     landing_company: { },
     available_currencies: { },
-    default_currency: { },
+    default_currency: 'USD',
 });
 
 export default (state = initialState, action) => {


### PR DESCRIPTION
… throws error when default currency in state is an empty object either empty string, but with setting it to default USD it works)