### PR TITLE
bug fix: hamburger doesn't respond when clicked.

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,6 @@
     "react": "^16.0.0",
     "react-addons-css-transition-group": "^15.4.0",
     "react-dom": "^16.0.0",
-    "react-fastclick": "^3.0.2",
     "react-intl": "^2.1.5",
     "react-redux": "^5.0.6",
     "react-router": "^3.0.0",

--- a/src/_store/root.js
+++ b/src/_store/root.js
@@ -1,5 +1,4 @@
 import React, { PureComponent } from 'react';
-import initReactFastclick from 'react-fastclick';
 import { addLocaleData } from 'react-intl';
 import { Provider } from 'react-redux';
 import { Router, hashHistory } from 'react-router';
@@ -15,7 +14,6 @@ import BootProvider from './BootProvider';
 export const history = syncHistoryWithStore(hashHistory, store);
 
 history.listen(location => trackRoute(location.pathname));
-initReactFastclick();
 
 addLocaleData({
     locale: 'bg-bg',


### PR DESCRIPTION
Seems to only happen in development (localhost and running cordova in debug mode), which can be annoying. I did a quick read up on why on the [original fastclick project](https://github.com/ftlabs/fastclick); turns out there a 300ms delay from the time you tap the button to fire a click event, but, for newer browsers this is no issue:

> Note: As of late 2015 most mobile browsers - notably Chrome and Safari - no longer have a 300ms touch delay, so fastclick offers no benefit on newer browsers, and risks introducing bugs into your application. Consider carefully whether you really need to use it.

So, no point having this extension if it introduces this bug.